### PR TITLE
Managed Agent using Downstream link 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,20 +23,20 @@ install:
 	@make build
 
 clean_containers:
-	@(docker stop agent 2>/dev/null || true) && (docker rm agent 2>/dev/null || true)
-	@(docker stop node 2>/dev/null || true) && (docker rm node 2>/dev/null || true)
-	@(docker stop cleaner 2>/dev/null || true) && (docker rm cleaner 2>/dev/null || true)
-	@(docker stop test_server 2>/dev/null || true) && (docker rm test_server 2>/dev/null || true)
+	@docker stop agent 2>/dev/null || true
+	@docker stop node 2>/dev/null || true
+	@docker stop cleaner 2>/dev/null || true
+	@docker stop test_server 2>/dev/null || true
 
 run:
 	@mkdir -p $(shell pwd)/logs
 	@rm -rf $(shell pwd)/logs/*.log
 	@make clean_containers
 	@if [ ! "$(sudo docker network ls | grep devnet)" ]; then sudo docker network create devnet || true; fi
-	@docker run --network=devnet --name node -p 7513:7513 spacemesh/node:latest /go/src/github.com/spacemeshos/go-spacemesh/go-spacemesh >> $(shell pwd)/logs/node.log 2>&1 &
-	@docker run --network=devnet --name cleaner -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet spacemesh/devnet_agent:latest python3 /opt/devnet/base_cleaner.py >> $(shell pwd)/logs/cleaner.log 2>&1
-	@docker run --network=devnet --name agent -p 8080:8080 -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet -v $(shell pwd)/logs:/opt/logs spacemesh/devnet_agent:latest python3 /opt/devnet/base_test_agent.py >> $(shell pwd)/logs/test.log 2>&1 &
-	@docker run --network=devnet --name test_server -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet spacemesh/devnet_agent:latest python3 /opt/devnet/tests.py >> $(shell pwd)/logs/test.log 2>&1 &
+	@docker run --rm --network=devnet --name node -p 7513:7513 spacemesh/node:latest /go/src/github.com/spacemeshos/go-spacemesh/go-spacemesh >> $(shell pwd)/logs/node.log 2>&1 &
+	@docker run --rm --network=devnet --name cleaner -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet spacemesh/devnet_agent:latest python3 /opt/devnet/base_cleaner.py >> $(shell pwd)/logs/cleaner.log 2>&1
+	@docker run --rm --network=devnet --name agent -p 8080:8080 -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet -v $(shell pwd)/logs:/opt/logs spacemesh/devnet_agent:latest python3 /opt/devnet/base_test_agent.py >> $(shell pwd)/logs/test.log 2>&1 &
+	@docker run --rm --network=devnet --name test_server -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet spacemesh/devnet_agent:latest python3 /opt/devnet/tests.py >> $(shell pwd)/logs/test.log 2>&1 &
 
 build:
 	@docker build -f $(shell pwd)/agent/Dockerfile -t spacemesh/devnet_agent:latest .

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ run:
 	@make clean_containers
 	@if [ ! "$(sudo docker network ls | grep devnet)" ]; then sudo docker network create devnet || true; fi
 	@docker run --network=devnet --name node -p 7513:7513 spacemesh/node:latest /go/src/github.com/spacemeshos/go-spacemesh/go-spacemesh >> $(shell pwd)/logs/node.log 2>&1 &
-	@docker run --network=devnet --name cleaner -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet spacemesh/devnet_agent:latest python3 /opt/devnet/base_cleaner.py >> $(shell pwd)/logs/cleaner.log 2>&1 & && sleep 10
+	@docker run --network=devnet --name cleaner -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet spacemesh/devnet_agent:latest python3 /opt/devnet/base_cleaner.py >> $(shell pwd)/logs/cleaner.log 2>&1 &&\
 	@docker run --network=devnet --name agent -p 8080:8080 -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet -v $(shell pwd)/logs:/opt/logs spacemesh/devnet_agent:latest python3 /opt/devnet/base_test_agent.py >> $(shell pwd)/logs/test.log 2>&1 &
 	@docker run --network=devnet --name test_server -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet spacemesh/devnet_agent:latest python3 /opt/devnet/tests.py >> $(shell pwd)/logs/test.log 2>&1 &
 

--- a/Makefile
+++ b/Makefile
@@ -22,19 +22,25 @@ install:
 	@apt install docker-ce -y
 	@make build
 
+clean_containers:
+	@(docker stop agent 2>/dev/null || true) &&\
+	(docker rm agent 2>/dev/null || true)
+	@(docker stop node 2>/dev/null || true) &&\
+	(docker rm node 2>/dev/null || true)
+	@(docker stop cleaner 2>/dev/null || true) &&\
+	(docker rm cleaner 2>/dev/null || true)
+	@(docker stop test_server 2>/dev/null || true) &&\
+	(docker rm test_server 2>/dev/null || true)
+
 run:
 	@mkdir -p $(shell pwd)/logs
 	@rm -rf $(shell pwd)/logs/*.log
+	@make clean_containers
 	@if [ ! "$(sudo docker network ls | grep devnet)" ]; then sudo docker network create devnet || true; fi
-	@(docker stop agent 2>/dev/null || true) &&\
-	(docker rm agent 2>/dev/null || true) &&\
-	docker run --network=devnet --name agent -p 8080:8080 -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet -v $(shell pwd)/logs:/opt/logs spacemesh/devnet_agent:latest python3 /opt/devnet/base_test_agent.py >> $(shell pwd)/logs/test.log 2>&1 &
-	@(docker stop node 2>/dev/null || true) &&\
-	(docker rm node 2>/dev/null || true) &&\
-	docker run --network=devnet --name node -p 7513:7513 spacemesh/node:latest /go/src/github.com/spacemeshos/go-spacemesh/go-spacemesh >> $(shell pwd)/logs/node.log 2>&1 &
-	@(docker stop test_server 2>/dev/null || true) &&\
-	(docker rm test_server 2>/dev/null || true) &&\
-	docker run --network=devnet --name test_server -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet spacemesh/devnet_agent:latest python3 /opt/devnet/tests.py >> $(shell pwd)/logs/test.log 2>&1 &
+	@docker run --network=devnet --name node -p 7513:7513 spacemesh/node:latest /go/src/github.com/spacemeshos/go-spacemesh/go-spacemesh >> $(shell pwd)/logs/node.log 2>&1 &
+	@docker run --network=devnet --name cleaner -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet spacemesh/devnet_agent:latest python3 /opt/devnet/base_cleaner.py >> $(shell pwd)/logs/cleaner.log 2>&1 & && sleep 10
+	@docker run --network=devnet --name agent -p 8080:8080 -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet -v $(shell pwd)/logs:/opt/logs spacemesh/devnet_agent:latest python3 /opt/devnet/base_test_agent.py >> $(shell pwd)/logs/test.log 2>&1 &
+	@docker run --network=devnet --name test_server -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet spacemesh/devnet_agent:latest python3 /opt/devnet/tests.py >> $(shell pwd)/logs/test.log 2>&1 &
 
 build:
 	@docker build -f $(shell pwd)/agent/Dockerfile -t spacemesh/devnet_agent:latest .

--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,10 @@ install:
 	@make build
 
 clean_containers:
-	@(docker stop agent 2>/dev/null || true) &&\
-	(docker rm agent 2>/dev/null || true)
-	@(docker stop node 2>/dev/null || true) &&\
-	(docker rm node 2>/dev/null || true)
-	@(docker stop cleaner 2>/dev/null || true) &&\
-	(docker rm cleaner 2>/dev/null || true)
-	@(docker stop test_server 2>/dev/null || true) &&\
-	(docker rm test_server 2>/dev/null || true)
+	@(docker stop agent 2>/dev/null || true) && (docker rm agent 2>/dev/null || true)
+	@(docker stop node 2>/dev/null || true) && (docker rm node 2>/dev/null || true)
+	@(docker stop cleaner 2>/dev/null || true) && (docker rm cleaner 2>/dev/null || true)
+	@(docker stop test_server 2>/dev/null || true) && (docker rm test_server 2>/dev/null || true)
 
 run:
 	@mkdir -p $(shell pwd)/logs
@@ -38,7 +34,7 @@ run:
 	@make clean_containers
 	@if [ ! "$(sudo docker network ls | grep devnet)" ]; then sudo docker network create devnet || true; fi
 	@docker run --network=devnet --name node -p 7513:7513 spacemesh/node:latest /go/src/github.com/spacemeshos/go-spacemesh/go-spacemesh >> $(shell pwd)/logs/node.log 2>&1 &
-	@docker run --network=devnet --name cleaner -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet spacemesh/devnet_agent:latest python3 /opt/devnet/base_cleaner.py >> $(shell pwd)/logs/cleaner.log 2>&1 &&\
+	@docker run --network=devnet --name cleaner -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet spacemesh/devnet_agent:latest python3 /opt/devnet/base_cleaner.py >> $(shell pwd)/logs/cleaner.log 2>&1
 	@docker run --network=devnet --name agent -p 8080:8080 -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet -v $(shell pwd)/logs:/opt/logs spacemesh/devnet_agent:latest python3 /opt/devnet/base_test_agent.py >> $(shell pwd)/logs/test.log 2>&1 &
 	@docker run --network=devnet --name test_server -e PUBSUB_VERIFICATION_TOKEN='1234' -e PUBSUB_TOPIC='topic' -e GOOGLE_CLOUD_PROJECT='spacemesh-198810' -v $(shell pwd)/tests:/opt/devnet spacemesh/devnet_agent:latest python3 /opt/devnet/tests.py >> $(shell pwd)/logs/test.log 2>&1 &
 

--- a/tests/base_cleaner.py
+++ b/tests/base_cleaner.py
@@ -10,7 +10,7 @@ class BaseDevnetCleaner:
 
         subscription_name_upstream = config.CONFIG['subscription_name_upstream']
         self.subscriber_upstream = pubsub_v1.SubscriberClient()
-        self.subscription_path_downstream = self.subscriber_upstream.subscription_path(project, subscription_name_upstream)
+        self.subscription_path_upstream = self.subscriber_upstream.subscription_path(project, subscription_name_upstream)
 
         subscription_name_downstream = config.CONFIG['subscription_name_downstream']
         self.subscriber_downstream = pubsub_v1.SubscriberClient()

--- a/tests/base_cleaner.py
+++ b/tests/base_cleaner.py
@@ -20,7 +20,7 @@ class BaseDevnetCleaner:
         message.ack()
 
     def cleanup(self, subscriber, subscription_path):
-        self.subscriber.subscribe(self.subscription_path, callback=self.callback)
+        subscriber.subscribe(subscription_path, callback=self.callback)
         while not self.endFlag:
             self.endFlag = True
             time.sleep(2)

--- a/tests/base_cleaner.py
+++ b/tests/base_cleaner.py
@@ -1,5 +1,6 @@
 import config
 from google.cloud import pubsub_v1
+import time
 
 class BaseDevnetCleaner:
     def __init__(self):

--- a/tests/base_cleaner.py
+++ b/tests/base_cleaner.py
@@ -27,5 +27,5 @@ class BaseDevnetCleaner:
 
 if __name__ == '__main__':
     t = BaseDevnetCleaner()
-    t.cleanup(subscriber_downstream, subscription_path_downstream)
-    t.cleanup(subscriber_upstream, subscription_path_upstream)
+    t.cleanup(t.subscriber_downstream, t.subscription_path_downstream)
+    t.cleanup(t.subscriber_upstream, t.subscription_path_upstream)

--- a/tests/base_cleaner.py
+++ b/tests/base_cleaner.py
@@ -1,0 +1,31 @@
+import config
+from google.cloud import pubsub_v1
+
+class BaseDevnetCleaner:
+    def __init__(self):
+        self.endFlag = False
+    
+        project = config.CONFIG['project']
+
+        subscription_name_upstream = config.CONFIG['subscription_name_upstream']
+        self.subscriber_upstream = pubsub_v1.SubscriberClient()
+        self.subscription_path_downstream = self.subscriber_upstream.subscription_path(project, subscription_name_upstream)
+
+        subscription_name_downstream = config.CONFIG['subscription_name_downstream']
+        self.subscriber_downstream = pubsub_v1.SubscriberClient()
+        self.subscription_path_downstream = self.subscriber_downstream.subscription_path(project, subscription_name_downstream)
+
+    def callback(self, message):
+        self.endFlag = False
+        message.ack()
+
+    def cleanup(self, subscriber, subscription_path):
+        self.subscriber.subscribe(self.subscription_path, callback=self.callback)
+        while not self.endFlag:
+            self.endFlag = True
+            time.sleep(2)
+
+if __name__ == '__main__':
+    t = BaseDevnetCleaner()
+    t.cleanup(subscriber_downstream, subscription_path_downstream)
+    t.cleanup(subscriber_upstream, subscription_path_upstream)

--- a/tests/base_test_agent.py
+++ b/tests/base_test_agent.py
@@ -20,7 +20,7 @@ class BaseDevnetAgent:
     def callback(self, message):
         self.message = message.data
         message.ack()
-        print(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S') + " GOT_DOWN_MSG " + self.message) 
+        print(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S') + " GOT_DOWN_MSG " + self.message.encode('utf-8')) 
         if b'END' == self.message:
             self.endFlag = True
         if b'SEND_UP' == self.message:

--- a/tests/base_test_agent.py
+++ b/tests/base_test_agent.py
@@ -3,6 +3,7 @@ from google.cloud import pubsub_v1
 import time
 import re
 import datetime
+from subprocess import call
 
 class BaseDevnetAgent:
     def __init__(self):
@@ -22,11 +23,14 @@ class BaseDevnetAgent:
         message.ack()
         print(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S') + " GOT_DOWN_MSG " + "".join(map(chr, self.message))) 
         if b'END' == self.message:
+            call(["docker stop node"])
             self.endFlag = True
-        if b'SEND_UP' == self.message:
+        elif b'SEND_UP' == self.message:
             self.send('UP')
-        if b'GET_NODE_ID' == self.message:
+        elif b'GET_NODE_ID' == self.message:
             self.send(self.get_node_id())
+        elif b'SHUTDOWN_NODE' == self.message:
+            call(["docker stop node"])
 
     def act_on_request(self):
         self.subscriber_downstream.subscribe(self.subscription_path_downstream, callback=self.callback)

--- a/tests/base_test_agent.py
+++ b/tests/base_test_agent.py
@@ -23,7 +23,6 @@ class BaseDevnetAgent:
         message.ack()
         print(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S') + " GOT_DOWN_MSG " + "".join(map(chr, self.message))) 
         if b'END' == self.message:
-            call(["docker stop node"])
             self.endFlag = True
         elif b'SEND_UP' == self.message:
             self.send('UP')

--- a/tests/base_test_agent.py
+++ b/tests/base_test_agent.py
@@ -5,10 +5,32 @@ import re
 
 class BaseDevnetAgent:
     def __init__(self):
+        self.endFlag = False
+    
         project = config.CONFIG['project']
         topic_name_upstream = config.CONFIG['topic_name_upstream']
         self.publisher_upstream = pubsub_v1.PublisherClient()
         self.topic_path_upstream = self.publisher_upstream.topic_path(project, topic_name_upstream)
+
+        subscription_name_downstream = config.CONFIG['subscription_name_downstream']
+        self.subscriber_downstream = pubsub_v1.SubscriberClient()
+        self.subscription_path_downstream = self.subscriber_downstream.subscription_path(project, subscription_name_downstream)
+
+    def callback(self, message):
+        self.message = message.data
+        message.ack()
+        print(self.message) 
+        if b'END' == self.message:
+            self.endFlag = True
+        if b'SEND_UP' == self.message:
+            self.send('UP')
+        if b'GET_NODE_ID' == self.message:
+            self.send(self.get_node_id())
+
+    def act_on_request():
+        self.subscriber_downstream.subscribe(self.subscription_path_downstream, callback=self.callback)
+        while !self.endFlag:
+            time.sleep(1)
 
     def send(self, data):
         data = data.encode('utf-8')
@@ -28,5 +50,4 @@ class BaseDevnetAgent:
 
 if __name__ == '__main__':
     t = BaseDevnetAgent()
-#    t.send('UP')
-    t.send(t.get_node_id())
+    t.act_on_request()

--- a/tests/base_test_agent.py
+++ b/tests/base_test_agent.py
@@ -27,7 +27,7 @@ class BaseDevnetAgent:
         if b'GET_NODE_ID' == self.message:
             self.send(self.get_node_id())
 
-    def act_on_request():
+    def act_on_request(self):
         self.subscriber_downstream.subscribe(self.subscription_path_downstream, callback=self.callback)
         while not self.endFlag:
             time.sleep(1)

--- a/tests/base_test_agent.py
+++ b/tests/base_test_agent.py
@@ -6,13 +6,13 @@ import re
 class BaseDevnetAgent:
     def __init__(self):
         project = config.CONFIG['project']
-        topic_name = config.CONFIG['topic_name']
-        self.publisher = pubsub_v1.PublisherClient()
-        self.topic_path = self.publisher.topic_path(project, topic_name)
+        topic_name_upstream = config.CONFIG['topic_name_upstream']
+        self.publisher_upstream = pubsub_v1.PublisherClient()
+        self.topic_path_upstream = self.publisher_upstream.topic_path(project, topic_name_upstream)
 
     def send(self, data):
         data = data.encode('utf-8')
-        self.publisher.publish(self.topic_path, data=data)
+        self.publisher_upstream.publish(self.topic_path_upstream, data=data)
 
     def get_node_id(self):
         time.sleep(15)

--- a/tests/base_test_agent.py
+++ b/tests/base_test_agent.py
@@ -2,6 +2,7 @@ import config
 from google.cloud import pubsub_v1
 import time
 import re
+import datetime
 
 class BaseDevnetAgent:
     def __init__(self):
@@ -19,7 +20,7 @@ class BaseDevnetAgent:
     def callback(self, message):
         self.message = message.data
         message.ack()
-        print(self.message) 
+        print(datetime.date.today().strftime('%Y-%m-%d %H:%M:%S') + " GOT_DOWN_MSG " + self.message) 
         if b'END' == self.message:
             self.endFlag = True
         if b'SEND_UP' == self.message:

--- a/tests/base_test_agent.py
+++ b/tests/base_test_agent.py
@@ -20,7 +20,7 @@ class BaseDevnetAgent:
     def callback(self, message):
         self.message = message.data
         message.ack()
-        print(datetime.date.today().strftime('%Y-%m-%d %H:%M:%S') + " GOT_DOWN_MSG " + self.message) 
+        print(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S') + " GOT_DOWN_MSG " + self.message) 
         if b'END' == self.message:
             self.endFlag = True
         if b'SEND_UP' == self.message:

--- a/tests/base_test_agent.py
+++ b/tests/base_test_agent.py
@@ -29,7 +29,7 @@ class BaseDevnetAgent:
         elif b'GET_NODE_ID' == self.message:
             self.send(self.get_node_id())
         elif b'SHUTDOWN_NODE' == self.message:
-            call(["docker stop node"])
+            pass
 
     def act_on_request(self):
         self.subscriber_downstream.subscribe(self.subscription_path_downstream, callback=self.callback)

--- a/tests/base_test_agent.py
+++ b/tests/base_test_agent.py
@@ -29,7 +29,7 @@ class BaseDevnetAgent:
 
     def act_on_request():
         self.subscriber_downstream.subscribe(self.subscription_path_downstream, callback=self.callback)
-        while !self.endFlag:
+        while not self.endFlag:
             time.sleep(1)
 
     def send(self, data):

--- a/tests/base_test_agent.py
+++ b/tests/base_test_agent.py
@@ -20,7 +20,7 @@ class BaseDevnetAgent:
     def callback(self, message):
         self.message = message.data
         message.ack()
-        print(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S') + " GOT_DOWN_MSG " + self.message.encode('utf-8')) 
+        print(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S') + " GOT_DOWN_MSG " + "".join(map(chr, self.message))) 
         if b'END' == self.message:
             self.endFlag = True
         if b'SEND_UP' == self.message:

--- a/tests/base_test_ci.py
+++ b/tests/base_test_ci.py
@@ -12,7 +12,7 @@ class BaseTest(unittest.TestCase):
         project = config.CONFIG['project']
         subscription_name_upstream = config.CONFIG['subscription_name_upstream']
         self.subscriber_upstream = pubsub_v1.SubscriberClient()
-        self.subscription_path = self.subscriber_upstream.subscription_path(project, subscription_name_upstream)
+        self.subscription_path_upstream = self.subscriber_upstream.subscription_path(project, subscription_name_upstream)
 
     def callback(self, message):
         self.message = message.data

--- a/tests/base_test_ci.py
+++ b/tests/base_test_ci.py
@@ -14,10 +14,18 @@ class BaseTest(unittest.TestCase):
         self.subscriber_upstream = pubsub_v1.SubscriberClient()
         self.subscription_path_upstream = self.subscriber_upstream.subscription_path(project, subscription_name_upstream)
 
+        topic_name_downstream = config.CONFIG['topic_name_downstream']
+        self.publisher_downstream = pubsub_v1.PublisherClient()
+        self.topic_path_downstream = self.publisher_downstream.topic_path(project, topic_name_downstream)
+
     def callback(self, message):
         self.message = message.data
         message.ack()
         self.endFlag = True
+
+    def send(self, data):
+        data = data.encode('utf-8')
+        self.publisher_downstream.publish(self.topic_path_downstream, data=data)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/base_test_ci.py
+++ b/tests/base_test_ci.py
@@ -10,9 +10,9 @@ class BaseTest(unittest.TestCase):
         self.testLen = 20
         self.message = b'NULL'
         project = config.CONFIG['project']
-        subscription_name = config.CONFIG['subscription_name']
-        self.subscriber = pubsub_v1.SubscriberClient()
-        self.subscription_path = self.subscriber.subscription_path(project, subscription_name)
+        subscription_name_upstream = config.CONFIG['subscription_name_upstream']
+        self.subscriber_upstream = pubsub_v1.SubscriberClient()
+        self.subscription_path = self.subscriber_upstream.subscription_path(project, subscription_name_upstream)
 
     def callback(self, message):
         self.message = message.data

--- a/tests/base_test_ci.py
+++ b/tests/base_test_ci.py
@@ -13,10 +13,14 @@ class BaseTest(unittest.TestCase):
         subscription_name_upstream = config.CONFIG['subscription_name_upstream']
         self.subscriber_upstream = pubsub_v1.SubscriberClient()
         self.subscription_path_upstream = self.subscriber_upstream.subscription_path(project, subscription_name_upstream)
+        self.subscriber_upstream.subscribe(self.subscription_path_upstream, callback=self.callback)
 
         topic_name_downstream = config.CONFIG['topic_name_downstream']
         self.publisher_downstream = pubsub_v1.PublisherClient()
         self.topic_path_downstream = self.publisher_downstream.topic_path(project, topic_name_downstream)
+
+    def tearDown(self):
+        self.send('END')
 
     def callback(self, message):
         self.message = message.data
@@ -26,6 +30,17 @@ class BaseTest(unittest.TestCase):
     def send(self, data):
         data = data.encode('utf-8')
         self.publisher_downstream.publish(self.topic_path_downstream, data=data)
+
+    def wait_for_response(self):
+        for i in range(0, self.testLen):
+            if self.endFlag:
+                print(self.message)
+                break
+            time.sleep(1)
+
+    def send_and_wait(self, data):
+        self.send(data)
+        self.wait_for_response()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,7 +1,7 @@
 CONFIG = {
     'project': 'spacemesh-198810',
     'topic_name_upstream': 'devnet_tests',
-    'subscription_name_upstream': 'devnet_tests_ci'
-    'topic_name_downstream': 'devnet_tests_downstream'
+    'subscription_name_upstream': 'devnet_tests_ci',
+    'topic_name_downstream': 'devnet_tests_downstream',
     'subscription_name_downstream': 'devnet_tests_agent'
 }

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,5 +1,7 @@
 CONFIG = {
     'project': 'spacemesh-198810',
-    'topic_name': 'devnet_tests',
-    'subscription_name': 'devnet_tests_ci'
+    'topic_name_upstream': 'devnet_tests',
+    'subscription_name_upstream': 'devnet_tests_ci'
+    'topic_name_downstream': 'devnet_tests_downstream'
+    'subscription_name_downstream': 'devnet_tests_agent'
 }

--- a/tests/test_0.py
+++ b/tests/test_0.py
@@ -7,14 +7,8 @@ import unittest
 
 class Test0(BaseTest):
     def test_verifyUp(self):
-        self.subscriber_upstream.subscribe(self.subscription_path_upstream, callback=self.callback)
-        self.send('SEND_UP')
-        for i in range(0, self.testLen):
-            if self.endFlag:
-                break
-            time.sleep(1)
-        self.send('END')
-
+        self.send_and_wait('SEND_UP')
+        
         self.assertEqual(b'UP', self.message)
 
 if __name__ == '__main__':

--- a/tests/test_0.py
+++ b/tests/test_0.py
@@ -7,7 +7,7 @@ import unittest
 
 class Test0(BaseTest):
     def test_verifyUp(self):
-        self.subscriber.subscribe(self.subscription_path, callback=self.callback)
+        self.subscriber_upstream.subscribe(self.subscription_path_upstream, callback=self.callback)
         for i in range(0, self.testLen):
             if self.endFlag:
                 break

--- a/tests/test_0.py
+++ b/tests/test_0.py
@@ -8,10 +8,12 @@ import unittest
 class Test0(BaseTest):
     def test_verifyUp(self):
         self.subscriber_upstream.subscribe(self.subscription_path_upstream, callback=self.callback)
+        self.send('SEND_UP')
         for i in range(0, self.testLen):
             if self.endFlag:
                 break
             time.sleep(1)
+        self.send('END')
 
         self.assertEqual(b'UP', self.message)
 

--- a/tests/test_1.py
+++ b/tests/test_1.py
@@ -7,7 +7,7 @@ import unittest
 
 class Test1(BaseTest):
     def test_sendId(self):
-        self.subscriber.subscribe(self.subscription_path, callback=self.callback)
+        self.subscriber_upstream.subscribe(self.subscription_path_upstream, callback=self.callback)
         for i in range(0, self.testLen):
             if self.endFlag:
                 print(self.message)

--- a/tests/test_1.py
+++ b/tests/test_1.py
@@ -8,11 +8,13 @@ import unittest
 class Test1(BaseTest):
     def test_sendId(self):
         self.subscriber_upstream.subscribe(self.subscription_path_upstream, callback=self.callback)
+        self.send('GET_NODE_ID')
         for i in range(0, self.testLen):
             if self.endFlag:
                 print(self.message)
                 break
             time.sleep(1)
+        self.send('END')
 
         self.assertNotEqual(b'NULL', self.message)
         self.assertLess(5, len(self.message))

--- a/tests/test_1.py
+++ b/tests/test_1.py
@@ -7,14 +7,7 @@ import unittest
 
 class Test1(BaseTest):
     def test_sendId(self):
-        self.subscriber_upstream.subscribe(self.subscription_path_upstream, callback=self.callback)
-        self.send('GET_NODE_ID')
-        for i in range(0, self.testLen):
-            if self.endFlag:
-                print(self.message)
-                break
-            time.sleep(1)
-        self.send('END')
+        self.send_and_wait('GET_NODE_ID')
 
         self.assertNotEqual(b'NULL', self.message)
         self.assertLess(5, len(self.message))


### PR DESCRIPTION
1. Create a downstream link to send messages from CI to agent
2. Turn the agent to listen on the downstream link, and stop only when it get a message (and do other stuff based on commands)
3. Send messages from the CI in the start and end of the tests
4. Add cleaner script that runs in the beginning of the run to cleanup the queues