### PR TITLE
Node Control in Agent

### DIFF
--- a/tests/base_test_agent.py
+++ b/tests/base_test_agent.py
@@ -5,6 +5,7 @@ import datetime
 from subprocess import call
 import spur
 import os
+import dockers
 
 class BaseDevnetAgent:
     def __init__(self):

--- a/tests/base_test_agent.py
+++ b/tests/base_test_agent.py
@@ -1,11 +1,11 @@
 import config
+from dockers import Docker
 from google.cloud import pubsub_v1
 import time
 import datetime
 from subprocess import call
 import spur
 import os
-import dockers
 
 class BaseDevnetAgent:
     def __init__(self):

--- a/tests/base_test_agent.py
+++ b/tests/base_test_agent.py
@@ -17,6 +17,9 @@ class BaseDevnetAgent:
         self.topic_path_upstream = self.publisher_upstream.topic_path(project, topic_name_upstream)
 
         self.node = os.environ['NODE']
+        docker = Docker()
+        docker.stop('node_' + str(self.agents))
+        docker.start('docker run --network=devnet --name node_' + self.node + ' -p ' + str(7513 + self.node) + ':7513 -v /root/spacemesh/devnet/logs:/root/.spacemesh/nodes/ spacemesh/node:latest /go/src/github.com/spacemeshos/go-spacemesh/go-spacemesh')
         subscription_name_downstream = os.environ['SUBSCRIPTION_NAME_DOWNSTREAM']
         self.subscriber_downstream = pubsub_v1.SubscriberClient()
         self.subscription_path_downstream = self.subscriber_downstream.subscription_path(project, subscription_name_downstream)
@@ -30,9 +33,9 @@ class BaseDevnetAgent:
         )
         with shell:
             try:
-                result = shell.run(["docker", "stop", self.node])
+                result = shell.run(["docker", "stop", "node_" + self.node])
                 print('Node stopped: ' + "".join(map(chr, result.output)))
-                result = shell.run(["docker", "rm", self.node])
+                result = shell.run(["docker", "rm", "node_" + self.node])
                 print('Node removed: ' + "".join(map(chr, result.output)))
             except Exception as e:
                 print('Node stop/remove failed')

--- a/tests/base_test_agent.py
+++ b/tests/base_test_agent.py
@@ -19,7 +19,7 @@ class BaseDevnetAgent:
         self.node = os.environ['NODE']
         docker = Docker()
         docker.stop('node_' + self.node)
-        docker.start('docker run --network=devnet --name node_' + self.node + ' -p ' + str(7513 + self.node) + ':7513 -v /root/spacemesh/devnet/logs:/root/.spacemesh/nodes/ spacemesh/node:latest /go/src/github.com/spacemeshos/go-spacemesh/go-spacemesh')
+        docker.start('docker run --network=devnet --name node_' + self.node + ' -p ' + str(7513 + int(self.node)) + ':7513 -v /root/spacemesh/devnet/logs:/root/.spacemesh/nodes/ spacemesh/node:latest /go/src/github.com/spacemeshos/go-spacemesh/go-spacemesh')
         subscription_name_downstream = os.environ['SUBSCRIPTION_NAME_DOWNSTREAM']
         self.subscriber_downstream = pubsub_v1.SubscriberClient()
         self.subscription_path_downstream = self.subscriber_downstream.subscription_path(project, subscription_name_downstream)

--- a/tests/base_test_agent.py
+++ b/tests/base_test_agent.py
@@ -18,7 +18,7 @@ class BaseDevnetAgent:
 
         self.node = os.environ['NODE']
         docker = Docker()
-        docker.stop('node_' + str(self.agents))
+        docker.stop('node_' + self.node)
         docker.start('docker run --network=devnet --name node_' + self.node + ' -p ' + str(7513 + self.node) + ':7513 -v /root/spacemesh/devnet/logs:/root/.spacemesh/nodes/ spacemesh/node:latest /go/src/github.com/spacemeshos/go-spacemesh/go-spacemesh')
         subscription_name_downstream = os.environ['SUBSCRIPTION_NAME_DOWNSTREAM']
         self.subscriber_downstream = pubsub_v1.SubscriberClient()

--- a/tests/base_test_ci.py
+++ b/tests/base_test_ci.py
@@ -48,10 +48,8 @@ class BaseTest(unittest.TestCase):
 
     def start_node_agent_pair(self):
         docker = Docker()
-        docker.stop('node_' + str(self.agents))
-        docker.start('docker run --network=devnet --name node_' + str(self.agents) + ' -p ' + str(7513 + self.agents) + ':7513 -v /root/spacemesh/devnet/logs:/root/.spacemesh/nodes/ spacemesh/node:latest /go/src/github.com/spacemeshos/go-spacemesh/go-spacemesh')
         docker.stop('agent_' + str(self.agents))
-        docker.start('docker run --network=devnet --name agent_' + str(self.agents) + ' -v /root/spacemesh/devnet/tests:/opt/devnet -v /root/spacemesh/devnet/logs:/opt/logs -e SUBSCRIPTION_NAME_DOWNSTREAM=devnet_tests_agent_' + str(self.agents) + ' -e NODE=node_' + str(self.agents) + ' spacemesh/devnet_agent:latest python3 /opt/devnet/base_test_agent.py')
+        docker.start('docker run --network=devnet --name agent_' + str(self.agents) + ' -v /root/spacemesh/devnet/tests:/opt/devnet -v /root/spacemesh/devnet/logs:/opt/logs -e SUBSCRIPTION_NAME_DOWNSTREAM=devnet_tests_agent_' + str(self.agents) + ' -e NODE=' + str(self.agents) + ' spacemesh/devnet_agent:latest python3 /opt/devnet/base_test_agent.py')
         self.agents += 1
 
 if __name__ == '__main__':

--- a/tests/base_test_ci.py
+++ b/tests/base_test_ci.py
@@ -47,10 +47,11 @@ class BaseTest(unittest.TestCase):
         self.wait_for_response()
 
     def start_node_agent_pair(self):
-        Docker.stop('node_' + str(self.agents))
-        Docker.start('docker run --network=devnet --name node_' + str(self.agents) + ' -p ' + str(7513 + self.agents) + ':7513 -v /root/spacemesh/devnet/logs:/root/.spacemesh/nodes/ spacemesh/node:latest /go/src/github.com/spacemeshos/go-spacemesh/go-spacemesh')
-        Dockers.stop('agent_' + str(self.agents))
-        Dockers.start('docker run --network=devnet --name agent_' + str(self.agents) + ' -v /root/spacemesh/devnet/tests:/opt/devnet -v /root/spacemesh/devnet/logs:/opt/logs -e SUBSCRIPTION_NAME_DOWNSTREAM=devnet_tests_agent_' + str(self.agents) + ' -e NODE=node_' + str(self.agents) + ' spacemesh/devnet_agent:latest python3 /opt/devnet/base_test_agent.py')
+        docker = Docker()
+        docker.stop('node_' + str(self.agents))
+        docker.start('docker run --network=devnet --name node_' + str(self.agents) + ' -p ' + str(7513 + self.agents) + ':7513 -v /root/spacemesh/devnet/logs:/root/.spacemesh/nodes/ spacemesh/node:latest /go/src/github.com/spacemeshos/go-spacemesh/go-spacemesh')
+        docker.stop('agent_' + str(self.agents))
+        docker.start('docker run --network=devnet --name agent_' + str(self.agents) + ' -v /root/spacemesh/devnet/tests:/opt/devnet -v /root/spacemesh/devnet/logs:/opt/logs -e SUBSCRIPTION_NAME_DOWNSTREAM=devnet_tests_agent_' + str(self.agents) + ' -e NODE=node_' + str(self.agents) + ' spacemesh/devnet_agent:latest python3 /opt/devnet/base_test_agent.py')
         self.agents += 1
 
 if __name__ == '__main__':

--- a/tests/base_test_ci.py
+++ b/tests/base_test_ci.py
@@ -1,3 +1,4 @@
+from dockers import Docker
 import config
 import os
 import time

--- a/tests/base_test_ci.py
+++ b/tests/base_test_ci.py
@@ -45,49 +45,11 @@ class BaseTest(unittest.TestCase):
         self.send(data)
         self.wait_for_response()
 
-    def start_docker(self, cmd):
-        try:
-            print(cmd)
-            print(config.CONFIG['host'])
-            print(config.CONFIG['host_user'])
-            print(config.CONFIG['host_password'])
-            shell = spur.SshShell(
-                hostname=config.CONFIG['host'], 
-                username=config.CONFIG['host_user'], 
-                password=config.CONFIG['host_password'], 
-                missing_host_key=spur.ssh.MissingHostKey.accept
-            )
-            with shell:
-                result = shell.spawn(cmd.split(' '))
-                print('Docker started')
-        except Exception as e:
-            print('Docker start failed')
-            print(e.__doc__ )
-
-    def run_cmd_interactive(self, cmd):
-        try:
-            shell = spur.SshShell(
-                hostname=config.CONFIG['host'], 
-                username=config.CONFIG['host_user'], 
-                password=config.CONFIG['host_password'], 
-                missing_host_key=spur.ssh.MissingHostKey.accept
-            )
-            with shell:
-                result = shell.run(cmd.split(' '))
-                print('Run interactive: ' + cmd)
-        except Exception as e:
-            print('Run interactive failed: ' + cmd)
-            print(e.__doc__ )
-
-    def stop_docker(self, name):
-        self.run_cmd_interactive("docker stop " + name)
-        self.run_cmd_interactive("docker rm " + name)
-
     def start_node_agent_pair(self):
-        self.stop_docker('node_' + str(self.agents))
-        self.stop_docker('agent_' + str(self.agents))
-        self.start_docker('docker run --network=devnet --name node_' + str(self.agents) + ' -p ' + str(7513 + self.agents) + ':7513 -v /root/spacemesh/devnet/logs:/root/.spacemesh/nodes/ spacemesh/node:latest /go/src/github.com/spacemeshos/go-spacemesh/go-spacemesh')
-        self.start_docker('docker run --network=devnet --name agent_' + str(self.agents) + ' -v /root/spacemesh/devnet/tests:/opt/devnet -v /root/spacemesh/devnet/logs:/opt/logs -e SUBSCRIPTION_NAME_DOWNSTREAM=devnet_tests_agent_' + str(self.agents) + ' -e NODE=node_' + str(self.agents) + ' spacemesh/devnet_agent:latest python3 /opt/devnet/base_test_agent.py')
+        Docker.stop('node_' + str(self.agents))
+        Docker.start('docker run --network=devnet --name node_' + str(self.agents) + ' -p ' + str(7513 + self.agents) + ':7513 -v /root/spacemesh/devnet/logs:/root/.spacemesh/nodes/ spacemesh/node:latest /go/src/github.com/spacemeshos/go-spacemesh/go-spacemesh')
+        Dockers.stop('agent_' + str(self.agents))
+        Dockers.start('docker run --network=devnet --name agent_' + str(self.agents) + ' -v /root/spacemesh/devnet/tests:/opt/devnet -v /root/spacemesh/devnet/logs:/opt/logs -e SUBSCRIPTION_NAME_DOWNSTREAM=devnet_tests_agent_' + str(self.agents) + ' -e NODE=node_' + str(self.agents) + ' spacemesh/devnet_agent:latest python3 /opt/devnet/base_test_agent.py')
         self.agents += 1
 
 if __name__ == '__main__':

--- a/tests/dockers.py
+++ b/tests/dockers.py
@@ -1,0 +1,44 @@
+import config
+import spur
+
+class Docker():
+    def start(self, cmd):
+        try:
+            print(cmd)
+            print(config.CONFIG['host'])
+            print(config.CONFIG['host_user'])
+            print(config.CONFIG['host_password'])
+            shell = spur.SshShell(
+                hostname=config.CONFIG['host'], 
+                username=config.CONFIG['host_user'], 
+                password=config.CONFIG['host_password'], 
+                missing_host_key=spur.ssh.MissingHostKey.accept
+            )
+            with shell:
+                result = shell.spawn(cmd.split(' '))
+                print('Docker started')
+        except Exception as e:
+            print('Docker start failed')
+            print(e.__doc__ )
+
+    def run_cmd_interactive(self, cmd):
+        try:
+            shell = spur.SshShell(
+                hostname=config.CONFIG['host'], 
+                username=config.CONFIG['host_user'], 
+                password=config.CONFIG['host_password'], 
+                missing_host_key=spur.ssh.MissingHostKey.accept
+            )
+            with shell:
+                result = shell.run(cmd.split(' '))
+                print('Run interactive: ' + cmd)
+        except Exception as e:
+            print('Run interactive failed: ' + cmd)
+            print(e.__doc__ )
+
+    def stop(self, name):
+        self.run_cmd_interactive("docker stop " + name)
+        self.run_cmd_interactive("docker rm " + name)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Start the node start to agent to prepare for node configuration modification
In the meantime extract all docker/ssh logic to external class to better share logic between ci and agent + prepare for future K8S migration